### PR TITLE
Refactor the RSpec conditional

### DIFF
--- a/lib/assert_value.rb
+++ b/lib/assert_value.rb
@@ -477,9 +477,8 @@ class BeSameValueAs
     end
 end
 
-
 if defined?(RSpec)
-    RSpec.configure do |c|
+    RSpec.send(:configure) do |c|
         c.include AssertValueAssertion
     end
 end


### PR DESCRIPTION
While configuring FactoryGirlRails for a Rails 3 (3.2.12) app, I began encountering an issue while loading this gem. Because of the change to gem loading, the following error was being thrown:

```ruby
root_path/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.3/lib/bundler/runtime.rb:85:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'assert_value'. (Bundler::GemRequireError)
Gem Load Error is: private method `configure' called for RSpec:Module
Backtrace for gem load error 
root_path/dev/lib/assert_value/lib/assert_value.rb:482:in `<top (required)>'
```